### PR TITLE
Catch signals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,5 +32,3 @@ RUN set -ex \
 COPY run.sh filebeat.yml.tmpl get_device_ids.py ./
 RUN apk add --update --no-cache python py-pip
 RUN pip install requests
-ENTRYPOINT ["./run.sh"]
-CMD ["filebeat", "-e"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN set -ex \
   && rm -rf filebeat* \
   && apk del --virtual build-tools
 
-COPY run.sh filebeat.yml.tmpl ./
-
+COPY run.sh filebeat.yml.tmpl get_device_ids.py ./
+RUN apk add --update --no-cache python py-pip
+RUN pip install requests
 ENTRYPOINT ["./run.sh"]
 CMD ["filebeat", "-e"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,9 @@ RUN set -ex \
   && tar xzf sigil.tgz -C /usr/local/bin \
   && rm sigil.tgz
 
-ENV FILEBEAT_VERSION=6.2.4
-ENV FILEBEAT_SHA512=19d0a93a42a758b8c9e71ca2691130fe5998fcb717019e29864f6ce0a21d4880c1654581220f0ce0f6118c914629df2baa91e95728f4e6a333666dffdf04df20
+ENV FILEBEAT_VERSION=7.14.0
 RUN set -ex \
   && curl -Lo filebeat.tgz "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-${FILEBEAT_VERSION}-linux-x86_64.tar.gz" \
-  && echo "${FILEBEAT_SHA512}  filebeat.tgz" | sha512sum -c - \
   && tar xzf filebeat.tgz \
   && cp filebeat-*/filebeat /usr/local/bin \
   && cp filebeat-*/fields.yml ./ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,15 @@
-FROM frolvlad/alpine-glibc:alpine-3.7
-
-WORKDIR /app
-
-# install dumb-init, a simple process supervisor and init system
-ENV DUMB_INIT_VERSION 1.2.1
-RUN set -ex \
-  && apk add --virtual build-tools --no-cache curl build-base bash \
-  && curl -Lo dumb-init.tgz "https://github.com/Yelp/dumb-init/archive/v${DUMB_INIT_VERSION}.tar.gz" \
-  && tar xzf dumb-init.tgz \
-  && cd dumb-init-${DUMB_INIT_VERSION} \
-  && make \
-  && cp dumb-init /usr/bin \
-  && cd .. \
-  && rm -rf dumb-init*
-
+FROM ubuntu:20.04
+RUN apt-get update 
+RUN apt -y install curl wget python3 python3-pip
+RUN curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-7.14.0-amd64.deb
+RUN  dpkg -i filebeat-7.14.0-amd64.deb
+RUN wget https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_amd64.deb
+RUN dpkg -i dumb-init_*.deb
 ENV SIGIL_VERSION 0.4.0
 RUN set -ex \
   && curl -Lo sigil.tgz "https://github.com/gliderlabs/sigil/releases/download/v${SIGIL_VERSION}/sigil_${SIGIL_VERSION}_Linux_x86_64.tgz" \
   && tar xzf sigil.tgz -C /usr/local/bin \
   && rm sigil.tgz
-
-ENV FILEBEAT_VERSION=7.14.0
-RUN set -ex \
-  && curl -Lo filebeat.tgz "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-${FILEBEAT_VERSION}-linux-x86_64.tar.gz" \
-  && tar xzf filebeat.tgz \
-  && cp filebeat-*/filebeat /usr/local/bin \
-  && cp filebeat-*/fields.yml ./ \
-  && rm -rf filebeat* \
-  && apk del --virtual build-tools
-
-COPY run.sh filebeat.yml.tmpl get_device_ids.py ./
-RUN apk add --update --no-cache python py-pip
-RUN pip install requests
+WORKDIR /app
+COPY filebeat.yml.tmpl /app
+COPY FilebeatManager.py /app

--- a/FilebeatManager.py
+++ b/FilebeatManager.py
@@ -1,0 +1,62 @@
+import os
+import threading
+import signal
+import sys
+import time
+import subprocess
+
+
+
+class FilebeatManager(object):
+    def __init__(self):
+        self.thread = threading.Thread(target=self.start_filebeat, args=())
+
+    def start_filebeat(self):
+      command = 'filebeat -e -c filebeat.yml --path.config /app '
+      with open('filebeat.log', "w") as f:
+        process = subprocess.Popen(command.split(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        for c in iter(lambda: process.stdout.readline(), b''): 
+          sys.stdout.buffer.write(c)
+          f.buffer.write(c)
+
+    def handle_sig(self, signal, frame):
+        print("received signal!")
+        for i in range(45):
+            print("Filebeat manager will exit in {} second...".format(45-i))
+            time.sleep(1)
+        os._exit(1)
+
+    def template_config(self):
+      # It is pretty silly use to sigil to template something
+      # from within a python script, however we are currently just attempting to
+      # replace the bash entrypoint with this script, we can improve later
+      try:
+        meta_vars = []
+        for var in os.environ.keys():
+            if 'NOMAD' in var:
+                meta_vars.append('{}={}'.format(var,os.environ[var]))
+        command = 'sigil -f ./filebeat.yml.tmpl meta_vars={}'.format(','.join(meta_vars)) 
+        process = subprocess.Popen(command.split(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        stdout = process.communicate()
+        config = stdout[0].decode()
+        rc = process.returncode
+        if rc != 0:
+            print("Templating config returned Non-zero!")
+            config = None
+      except Exception as e:
+        print("Exception: {}".format(e))
+        config = None
+      return config
+
+        
+if __name__ == "__main__":
+     mngr = FilebeatManager()
+     signal.signal(signal.SIGTERM, mngr.handle_sig)
+     signal.signal(signal.SIGINT, mngr.handle_sig)
+     config = mngr.template_config()
+     if not config:
+        print("could not generate config!")
+        sys.exit(1)
+     with open("filebeat.yml", 'w') as fh:
+         fh.write(config)
+     mngr.thread.start()

--- a/filebeat.yml.tmpl
+++ b/filebeat.yml.tmpl
@@ -24,12 +24,18 @@ filebeat:
             {{ if var . }}{{ . | replace "NOMAD_META_" "" | lower }}: {{ var . }}{{ end }}{{ end }}{{ end }}
     {{ if var "AMP_FARM" }}
     - type: log
-      keys_under_root: true
+      {{ if var "ENABLE_JSON" }}json:
+        keys_under_root: true
+        overwrite_keys: true
+        {{ if var "ADD_JSON_ERROR_KEY" }}add_error_key: true{{ end }}
+        {{ if var "JSON_MESSAGE_KEY" }}message_key: {{ var "JSON_MESSAGE_KEY" }}{{ end }}{{ end }}
       paths:
-        - {{ var "NOMAD_ALLOC_DIR" }}/logs/umd/* 
+        - {{ var "NOMAD_ALLOC_DIR" }}/umd/*
+      exclude_files:
+        - {{ var "NOMAD_TASK_NAME" }}
+      fields_under_root: true
       fields:
-        stream: stderr
-        type: log
+        stream: stdout
         {{ if var "ENVIRONMENT" }}environment: {{ var "ENVIRONMENT" }}{{ else }}#environment:{{ end }}
         {{ if $meta_vars }}nomad:
           meta:{{ range $meta_vars | split "," }}

--- a/filebeat.yml.tmpl
+++ b/filebeat.yml.tmpl
@@ -21,6 +21,7 @@ filebeat:
         job_name: {{ var "NOMAD_JOB_NAME" }}
         task_group: {{ var "NOMAD_GROUP_NAME" }}
         allocation_id: {{ var "NOMAD_ALLOC_ID" }}
+        device_id: {{ var "DEVICE_ID" }}
         {{ if var "ENVIRONMENT" }}environment: {{ var "ENVIRONMENT" }}{{ else }}#environment:{{ end }}
         {{ if $meta_vars }}nomad:
           meta:{{ range $meta_vars | split "," }}
@@ -38,6 +39,7 @@ filebeat:
         - {{ var "NOMAD_TASK_NAME" }}
       fields_under_root: true
       fields:
+        device_id: {{ var "DEVICE_ID" }}
         stream: umd_logs
         job_name: {{ var "NOMAD_JOB_NAME" }}
         task_group: {{ var "NOMAD_GROUP_NAME" }}
@@ -61,6 +63,7 @@ filebeat:
       fields_under_root: true
       fields:
         stream: cli_session_script
+        device_id: {{ var "DEVICE_ID" }}
         job_name: {{ var "NOMAD_JOB_NAME" }}
         task_group: {{ var "NOMAD_GROUP_NAME" }}
         allocation_id: {{ var "NOMAD_ALLOC_ID" }}
@@ -82,6 +85,7 @@ filebeat:
       fields_under_root: true
       fields:
         stream: stderr
+        device_id: {{ var "DEVICE_ID" }}
         job_name: {{ var "NOMAD_JOB_NAME" }}
         task_group: {{ var "NOMAD_GROUP_NAME" }}
         allocation_id: {{ var "NOMAD_ALLOC_ID" }}

--- a/filebeat.yml.tmpl
+++ b/filebeat.yml.tmpl
@@ -1,4 +1,4 @@
-{{ if var "NAME" }}name: {{ var "NAME" }}{{ else }}#name:{{ end }}
+name: {{ var "NOMAD_ALLOC_ID" }}
 {{ if var "TAGS" }}tags:{{ range var "TAGS" | split "," }}
   - "{{ . }}"{{ end }}{{ end }}
 filebeat:

--- a/filebeat.yml.tmpl
+++ b/filebeat.yml.tmpl
@@ -3,7 +3,7 @@
   - "{{ . }}"{{ end }}{{ end }}
 filebeat:
   registry_file: {{ var "NOMAD_TASK_DIR" }}/.filebeat
-  prospectors:
+  inputs:
     - type: log
       {{ if var "ENABLE_JSON" }}json:
         keys_under_root: true

--- a/filebeat.yml.tmpl
+++ b/filebeat.yml.tmpl
@@ -43,10 +43,10 @@ filebeat:
     {{ end }} 
     - type: log
        {{ if var "ENABLE_JSON" }}json:
-         keys_under_root: true
-         overwrite_keys: true
-         {{ if var "ADD_JSON_ERROR_KEY" }}add_error_key: true{{ end }}
-         {{ if var "JSON_MESSAGE_KEY" }}message_key: {{ var "JSON_MESSAGE_KEY" }}{{ end }}{{ end }}
+       keys_under_root: true
+       overwrite_keys: true
+       {{ if var "ADD_JSON_ERROR_KEY" }}add_error_key: true{{ end }}
+       {{ if var "JSON_MESSAGE_KEY" }}message_key: {{ var "JSON_MESSAGE_KEY" }}{{ end }}{{ end }}
        paths:
          - {{ var "NOMAD_ALLOC_DIR" }}/logs/*.stderr.*
        exclude_files:

--- a/filebeat.yml.tmpl
+++ b/filebeat.yml.tmpl
@@ -27,6 +27,7 @@ filebeat:
       keys_under_root: true
       overwrite_keys:
       paths:
+        - {{ var "NOMAD_ALLOC_DIR" }}/logs/umd/* 
       fields:
         stream: stderr
         type: log
@@ -34,7 +35,6 @@ filebeat:
         {{ if $meta_vars }}nomad:
           meta:{{ range $meta_vars | split "," }}
             {{ if var . }}{{ . | replace "NOMAD_META_" "" | lower }}: {{ var . }}{{ end }}{{ end }}{{ end }}
-        - {{ var "NOMAD_ALLOC_DIR" }}/logs/umd/* 
    {{ end }} 
    - type: log
       {{ if var "ENABLE_JSON" }}json:

--- a/filebeat.yml.tmpl
+++ b/filebeat.yml.tmpl
@@ -22,7 +22,21 @@ filebeat:
         {{ if $meta_vars }}nomad:
           meta:{{ range $meta_vars | split "," }}
             {{ if var . }}{{ . | replace "NOMAD_META_" "" | lower }}: {{ var . }}{{ end }}{{ end }}{{ end }}
+    {{ if var "AMP_FARM" }}
     - type: log
+      keys_under_root: true
+      overwrite_keys:
+      paths:
+      fields:
+        stream: stderr
+        type: log
+        {{ if var "ENVIRONMENT" }}environment: {{ var "ENVIRONMENT" }}{{ else }}#environment:{{ end }}
+        {{ if $meta_vars }}nomad:
+          meta:{{ range $meta_vars | split "," }}
+            {{ if var . }}{{ . | replace "NOMAD_META_" "" | lower }}: {{ var . }}{{ end }}{{ end }}{{ end }}
+        - {{ var "NOMAD_ALLOC_DIR" }}/logs/umd/* 
+   {{ end }} 
+   - type: log
       {{ if var "ENABLE_JSON" }}json:
         keys_under_root: true
         overwrite_keys: true

--- a/filebeat.yml.tmpl
+++ b/filebeat.yml.tmpl
@@ -25,7 +25,6 @@ filebeat:
     {{ if var "AMP_FARM" }}
     - type: log
       keys_under_root: true
-      overwrite_keys:
       paths:
         - {{ var "NOMAD_ALLOC_DIR" }}/logs/umd/* 
       fields:

--- a/filebeat.yml.tmpl
+++ b/filebeat.yml.tmpl
@@ -25,10 +25,10 @@ filebeat:
     {{ if var "AMP_FARM" }}
     - type: log
       {{ if var "ENABLE_JSON" }}json:
-        keys_under_root: true
-        overwrite_keys: true
-        {{ if var "ADD_JSON_ERROR_KEY" }}add_error_key: true{{ end }}
-        {{ if var "JSON_MESSAGE_KEY" }}message_key: {{ var "JSON_MESSAGE_KEY" }}{{ end }}{{ end }}
+      keys_under_root: true
+      overwrite_keys: true
+      {{ if var "ADD_JSON_ERROR_KEY" }}add_error_key: true{{ end }}
+      {{ if var "JSON_MESSAGE_KEY" }}message_key: {{ var "JSON_MESSAGE_KEY" }}{{ end }}{{ end }}
       paths:
         - {{ var "NOMAD_ALLOC_DIR" }}/umd/*
       exclude_files:
@@ -40,25 +40,25 @@ filebeat:
         {{ if $meta_vars }}nomad:
           meta:{{ range $meta_vars | split "," }}
             {{ if var . }}{{ . | replace "NOMAD_META_" "" | lower }}: {{ var . }}{{ end }}{{ end }}{{ end }}
-   {{ end }} 
-   - type: log
-      {{ if var "ENABLE_JSON" }}json:
-        keys_under_root: true
-        overwrite_keys: true
-        {{ if var "ADD_JSON_ERROR_KEY" }}add_error_key: true{{ end }}
-        {{ if var "JSON_MESSAGE_KEY" }}message_key: {{ var "JSON_MESSAGE_KEY" }}{{ end }}{{ end }}
-      paths:
-        - {{ var "NOMAD_ALLOC_DIR" }}/logs/*.stderr.*
-      exclude_files:
-        - {{ var "NOMAD_TASK_NAME" }}
-      fields_under_root: true
-      fields:
-        stream: stderr
-        type: log
-        {{ if var "ENVIRONMENT" }}environment: {{ var "ENVIRONMENT" }}{{ else }}#environment:{{ end }}
-        {{ if $meta_vars }}nomad:
-          meta:{{ range $meta_vars | split "," }}
-            {{ if var . }}{{ . | replace "NOMAD_META_" "" | lower }}: {{ var . }}{{ end }}{{ end }}{{ end }}
+    {{ end }} 
+    - type: log
+       {{ if var "ENABLE_JSON" }}json:
+         keys_under_root: true
+         overwrite_keys: true
+         {{ if var "ADD_JSON_ERROR_KEY" }}add_error_key: true{{ end }}
+         {{ if var "JSON_MESSAGE_KEY" }}message_key: {{ var "JSON_MESSAGE_KEY" }}{{ end }}{{ end }}
+       paths:
+         - {{ var "NOMAD_ALLOC_DIR" }}/logs/*.stderr.*
+       exclude_files:
+         - {{ var "NOMAD_TASK_NAME" }}
+       fields_under_root: true
+       fields:
+         stream: stderr
+         type: log
+         {{ if var "ENVIRONMENT" }}environment: {{ var "ENVIRONMENT" }}{{ else }}#environment:{{ end }}
+         {{ if $meta_vars }}nomad:
+           meta:{{ range $meta_vars | split "," }}
+             {{ if var . }}{{ . | replace "NOMAD_META_" "" | lower }}: {{ var . }}{{ end }}{{ end }}{{ end }}
 output:
 {{ if var "ES_HOST" }}  elasticsearch:
     hosts:{{ range var "ES_HOST" | split "," }}

--- a/filebeat.yml.tmpl
+++ b/filebeat.yml.tmpl
@@ -18,6 +18,9 @@ filebeat:
       fields_under_root: true
       fields:
         stream: stdout
+        job_name: {{ var "NOMAD_JOB_NAME" }}
+        task_group: {{ var "NOMAD_GROUP_NAME" }}
+        allocation_id: {{ var "NOMAD_ALLOC_ID" }}
         {{ if var "ENVIRONMENT" }}environment: {{ var "ENVIRONMENT" }}{{ else }}#environment:{{ end }}
         {{ if $meta_vars }}nomad:
           meta:{{ range $meta_vars | split "," }}
@@ -35,7 +38,32 @@ filebeat:
         - {{ var "NOMAD_TASK_NAME" }}
       fields_under_root: true
       fields:
-        stream: stdout
+        stream: umd_logs
+        job_name: {{ var "NOMAD_JOB_NAME" }}
+        task_group: {{ var "NOMAD_GROUP_NAME" }}
+        allocation_id: {{ var "NOMAD_ALLOC_ID" }}
+        {{ if var "ENVIRONMENT" }}environment: {{ var "ENVIRONMENT" }}{{ else }}#environment:{{ end }}
+        {{ if $meta_vars }}nomad:
+          meta:{{ range $meta_vars | split "," }}
+            {{ if var . }}{{ . | replace "NOMAD_META_" "" | lower }}: {{ var . }}{{ end }}{{ end }}{{ end }}
+    {{ end }} 
+    {{ if var "CLI_SESSION" }}
+    - type: log
+      {{ if var "ENABLE_JSON" }}json:
+      keys_under_root: true
+      overwrite_keys: true
+      {{ if var "ADD_JSON_ERROR_KEY" }}add_error_key: true{{ end }}
+      {{ if var "JSON_MESSAGE_KEY" }}message_key: {{ var "JSON_MESSAGE_KEY" }}{{ end }}{{ end }}
+      paths:
+        - {{ var "NOMAD_ALLOC_DIR" }}/logs/cli_session_script*
+      exclude_files:
+        - {{ var "NOMAD_TASK_NAME" }}
+      fields_under_root: true
+      fields:
+        stream: cli_session_script
+        job_name: {{ var "NOMAD_JOB_NAME" }}
+        task_group: {{ var "NOMAD_GROUP_NAME" }}
+        allocation_id: {{ var "NOMAD_ALLOC_ID" }}
         {{ if var "ENVIRONMENT" }}environment: {{ var "ENVIRONMENT" }}{{ else }}#environment:{{ end }}
         {{ if $meta_vars }}nomad:
           meta:{{ range $meta_vars | split "," }}
@@ -54,6 +82,9 @@ filebeat:
       fields_under_root: true
       fields:
         stream: stderr
+        job_name: {{ var "NOMAD_JOB_NAME" }}
+        task_group: {{ var "NOMAD_GROUP_NAME" }}
+        allocation_id: {{ var "NOMAD_ALLOC_ID" }}
         type: log
         {{ if var "ENVIRONMENT" }}environment: {{ var "ENVIRONMENT" }}{{ else }}#environment:{{ end }}
         {{ if $meta_vars }}nomad:

--- a/filebeat.yml.tmpl
+++ b/filebeat.yml.tmpl
@@ -42,23 +42,23 @@ filebeat:
             {{ if var . }}{{ . | replace "NOMAD_META_" "" | lower }}: {{ var . }}{{ end }}{{ end }}{{ end }}
     {{ end }} 
     - type: log
-       {{ if var "ENABLE_JSON" }}json:
-       keys_under_root: true
-       overwrite_keys: true
-       {{ if var "ADD_JSON_ERROR_KEY" }}add_error_key: true{{ end }}
-       {{ if var "JSON_MESSAGE_KEY" }}message_key: {{ var "JSON_MESSAGE_KEY" }}{{ end }}{{ end }}
-       paths:
-         - {{ var "NOMAD_ALLOC_DIR" }}/logs/*.stderr.*
-       exclude_files:
-         - {{ var "NOMAD_TASK_NAME" }}
-       fields_under_root: true
-       fields:
-         stream: stderr
-         type: log
-         {{ if var "ENVIRONMENT" }}environment: {{ var "ENVIRONMENT" }}{{ else }}#environment:{{ end }}
-         {{ if $meta_vars }}nomad:
-           meta:{{ range $meta_vars | split "," }}
-             {{ if var . }}{{ . | replace "NOMAD_META_" "" | lower }}: {{ var . }}{{ end }}{{ end }}{{ end }}
+      {{ if var "ENABLE_JSON" }}json:
+      keys_under_root: true
+      overwrite_keys: true
+      {{ if var "ADD_JSON_ERROR_KEY" }}add_error_key: true{{ end }}
+      {{ if var "JSON_MESSAGE_KEY" }}message_key: {{ var "JSON_MESSAGE_KEY" }}{{ end }}{{ end }}
+      paths:
+        - {{ var "NOMAD_ALLOC_DIR" }}/logs/*.stderr.*
+      exclude_files:
+        - {{ var "NOMAD_TASK_NAME" }}
+      fields_under_root: true
+      fields:
+        stream: stderr
+        type: log
+        {{ if var "ENVIRONMENT" }}environment: {{ var "ENVIRONMENT" }}{{ else }}#environment:{{ end }}
+        {{ if $meta_vars }}nomad:
+          meta:{{ range $meta_vars | split "," }}
+            {{ if var . }}{{ . | replace "NOMAD_META_" "" | lower }}: {{ var . }}{{ end }}{{ end }}{{ end }}
 output:
 {{ if var "ES_HOST" }}  elasticsearch:
     hosts:{{ range var "ES_HOST" | split "," }}

--- a/filebeat.yml.tmpl
+++ b/filebeat.yml.tmpl
@@ -2,7 +2,8 @@
 {{ if var "TAGS" }}tags:{{ range var "TAGS" | split "," }}
   - "{{ . }}"{{ end }}{{ end }}
 filebeat:
-  registry_file: {{ var "NOMAD_TASK_DIR" }}/.filebeat
+  registry:
+    path: {{ var "NOMAD_TASK_DIR" }}/.filebeat
   inputs:
     - type: log
       {{ if var "ENABLE_JSON" }}json:

--- a/filebeat.yml.tmpl
+++ b/filebeat.yml.tmpl
@@ -30,7 +30,7 @@ filebeat:
       {{ if var "ADD_JSON_ERROR_KEY" }}add_error_key: true{{ end }}
       {{ if var "JSON_MESSAGE_KEY" }}message_key: {{ var "JSON_MESSAGE_KEY" }}{{ end }}{{ end }}
       paths:
-        - {{ var "NOMAD_ALLOC_DIR" }}/umd/*
+        - {{ var "NOMAD_ALLOC_DIR" }}/logs/umd/*
       exclude_files:
         - {{ var "NOMAD_TASK_NAME" }}
       fields_under_root: true

--- a/get_device_ids.py
+++ b/get_device_ids.py
@@ -1,0 +1,11 @@
+import requests
+import os
+headers = {"X-Nomad-Token": os.environ['NOMAD_TOKEN']}
+r = requests.get('https://nomad.mythic-ai.com/v1/allocation/{}'.format(os.environ['NOMAD_ALLOC_ID']), headers=headers)
+allocation_tasks =  r.json()['AllocatedResources']['Tasks']
+for task in allocation_tasks.keys():
+    if task != 'batch_job_logger':
+        device_ids = []
+        for device in allocation_tasks[task]['Devices']:
+            device_ids = device_ids + device['DeviceIDs']
+        print(",".join(device_ids))

--- a/project.json
+++ b/project.json
@@ -1,0 +1,18 @@
+
+{
+  "version": "v1",
+  "product_group": "software_infrastructure",
+  "project": {
+    "name": "docker_nomad_filebeat",
+    "repo_url": "https://github.com/mythic-ai/docker_nomad_filebeat"
+   },
+   "artifacts": [
+      {
+        "name": "docker_nomad_filebeat_image",
+        "type": "docker_image",
+        "versions": {
+          "current": "0.0.1"
+        }
+      }
+   ]
+}

--- a/run.sh
+++ b/run.sh
@@ -26,5 +26,7 @@ done
 #export DEVICE_ID=$(python get_device_ids.py)
 sigil -f ./filebeat.yml.tmpl meta_vars=$meta_vars > ./filebeat.yml
 
-filebeat -e&
-while true; do sleep .5; done
+filebeat -e 2>&1 > filebeat.log&
+disown %+
+#bash /app/start_filebeat.sh
+tail -f filebeat.log

--- a/run.sh
+++ b/run.sh
@@ -29,5 +29,5 @@ done
 #export DEVICE_ID=$(python get_device_ids.py)
 sigil -f ./filebeat.yml.tmpl meta_vars=$meta_vars > ./filebeat.yml
 
-fileabeat -e&
+filebeat -e&
 while true; do sleep .5; done

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/dumb-init /bin/sh
-set -e
-
+set -x
 # We need to capture these signals we we gracefully exit 
 # Without missing logs 
 function control_c {

--- a/run.sh
+++ b/run.sh
@@ -2,14 +2,11 @@
 set -x
 # We need to capture these signals we we gracefully exit 
 # Without missing logs 
-function control_c {
-  echo "[!] waiting 45 seconds to finish writing logs before exiting..."
-  sleep 45
-  exit 
-}
 function cleanup()
 {
-    echo "$1"
+    echo "[!] Received Signal: $1"
+    echo "[!] waiting 45 seconds to finish writing logs before exiting..."
+    sleep 45
     exit 0
 }
 

--- a/run.sh
+++ b/run.sh
@@ -7,9 +7,16 @@ function control_c {
   sleep 45
   exit 
 }
-trap control_c SIGINT
-trap control_c SIGTERM
-trap control_c 0
+function cleanup()
+{
+    echo "$1"
+    exit 0
+}
+
+trap 'cleanup SIGINT' SIGINT
+trap 'cleanup TERM' SIGTERM
+trap 'cleanup SIGABRT' SIGABRT
+trap 'cleanup SIGKILL' SIGKIL
 
 for v in $(env | grep ^NOMAD_META_ | cut -d= -f1); do
   if [ -n "$meta_vars" ]; then

--- a/run.sh
+++ b/run.sh
@@ -12,6 +12,6 @@ done
 sigil -f ./filebeat.yml.tmpl meta_vars=$meta_vars > ./filebeat.yml
 
 if [[ $DEBUG -eq 'true' ]]
-   filebeat_option='-e'
+   then filebeat_option='-e'
 fi
 filebeat

--- a/run.sh
+++ b/run.sh
@@ -22,4 +22,5 @@ done
 #export DEVICE_ID=$(python get_device_ids.py)
 sigil -f ./filebeat.yml.tmpl meta_vars=$meta_vars > ./filebeat.yml
 
-fileabeat&
+fileabeat -e&
+while true; do sleep .5; done

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/dumb-init /bin/sh
 set -e
 
+# We need to capture these signals we we gracefully exit 
+# Without missing logs 
+function control_c {
+  echo "[!] waiting 45 seconds to finish writing logs before exiting..."
+  sleep 45
+  exit 
+}
+trap control_c SIGINT
+trap control_c SIGTERM
+
 for v in $(env | grep ^NOMAD_META_ | cut -d= -f1); do
   if [ -n "$meta_vars" ]; then
     meta_vars="${meta_vars},${v}"

--- a/run.sh
+++ b/run.sh
@@ -10,6 +10,7 @@ function control_c {
 }
 trap control_c SIGINT
 trap control_c SIGTERM
+trap control_c 0
 
 for v in $(env | grep ^NOMAD_META_ | cut -d= -f1); do
   if [ -n "$meta_vars" ]; then

--- a/run.sh
+++ b/run.sh
@@ -22,6 +22,4 @@ done
 #export DEVICE_ID=$(python get_device_ids.py)
 sigil -f ./filebeat.yml.tmpl meta_vars=$meta_vars > ./filebeat.yml
 
-
-
-exec "$@"
+eval "$@"

--- a/run.sh
+++ b/run.sh
@@ -11,4 +11,7 @@ done
 
 sigil -f ./filebeat.yml.tmpl meta_vars=$meta_vars > ./filebeat.yml
 
-exec "$@"
+if [[ $DEBUG -eq 'true' ]]
+   filebeat_option='-e'
+fi
+filebeat

--- a/run.sh
+++ b/run.sh
@@ -19,7 +19,7 @@ for v in $(env | grep ^NOMAD_META_ | cut -d= -f1); do
   fi
 done
 
-export DEVICE_ID=$(python get_device_ids.py)
+#export DEVICE_ID=$(python get_device_ids.py)
 sigil -f ./filebeat.yml.tmpl meta_vars=$meta_vars > ./filebeat.yml
 
 

--- a/run.sh
+++ b/run.sh
@@ -9,12 +9,9 @@ for v in $(env | grep ^NOMAD_META_ | cut -d= -f1); do
   fi
 done
 
+export DEVICE_ID=$(python get_device_ids.py)
 sigil -f ./filebeat.yml.tmpl meta_vars=$meta_vars > ./filebeat.yml
 
-#if [[ $DEBUG -eq 'true' ]]
-#   then filebeat_option='-e'
-#fi
-#filebeat
-#!/usr/bin/dumb-init /bin/sh
+
 
 exec "$@"

--- a/run.sh
+++ b/run.sh
@@ -11,7 +11,10 @@ done
 
 sigil -f ./filebeat.yml.tmpl meta_vars=$meta_vars > ./filebeat.yml
 
-if [[ $DEBUG -eq 'true' ]]
-   then filebeat_option='-e'
-fi
-filebeat
+#if [[ $DEBUG -eq 'true' ]]
+#   then filebeat_option='-e'
+#fi
+#filebeat
+#!/usr/bin/dumb-init /bin/sh
+
+exec "$@"

--- a/run.sh
+++ b/run.sh
@@ -22,4 +22,4 @@ done
 #export DEVICE_ID=$(python get_device_ids.py)
 sigil -f ./filebeat.yml.tmpl meta_vars=$meta_vars > ./filebeat.yml
 
-eval "$@"
+fileabeat&


### PR DESCRIPTION
This PR introduces several _major_ changes:

- We switch from alpine to ubuntu. This was done to make maintaining a more complex environment easier
- we switch from a bash entrypoint script to a python one, to facilitate more complex thread management
- we catch signals so prevent a job from exiting as soon nomad sends the intial SIGTERM

This allows filebeat to continue shipping logs for 45 seconds after the main task exits. 